### PR TITLE
S3 with DSN option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 go:
-- 1.9
+- "1.9"
+- "1.10"
 env:
   global:
     secure: aYrW+MfufFh4dql1eqmLNSXF8yYDov0FfCa1yMdpotvhLGK+IamlCKJlHMppYnULdHso9QuUKGl0HJAOv6QhBj+UK1BlDuxivJY1KDw2eXSByJeHgD0zgyscAZ2rk0X33K+VQyoT2ieOo3ObiaNqsuhXuGvbjRM8AqOI8IZ6VR7i8xHIFl7DY8/kjPwmD2Vs4ukwpc/Wni0voUM69xC14avJJjJ/9wjMOpxcaRx5k+Ke1NLcImuoDVl2h9DijNZZmTMRmp8qUBPbyVywDS0OSsX8EGHzmEV6f10rs3qjqjXciv37/xiy32vifDulmP5V3TCtcC9Y7vzHGyGFGcYoypi7c8H++lfychbjsMYNJ2iEAwR9m/M1435J1gbDmyKZklRK01EpKvdNnrybM1aSh7pescvRG2tSC8W9kgGyo+1GQr0fkPQdFHWeSCjBtANRr3d5Zq+DzNRo4ZQatfT4Rl0YnAMOVhZvNHZ1NzmzdQHQMZYgxlI4qqLMHuVKgq3PEVOd0KKtFaBQ213+COhvs31OMGs44p/GQkpFYolRJmEzzGOEd0+j6tnTFjuVkhS7gCEYGpUya9Jbyl3UKzfvnTQ7rzayTKErTZg0afajmIEkGLnCDUhFl8WREKnwIwwouPzMlxqe2UWKepYBu9CY6Y1DIWauMlpjpOqDnoW2jAM=
+
 before_install:
 - go get github.com/mattn/goveralls
+
 script:
 - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/danilobuerger/autocert-s3-cache.svg?branch=master)](https://travis-ci.org/danilobuerger/autocert-s3-cache) [![Coverage Status](https://coveralls.io/repos/github/danilobuerger/autocert-s3-cache/badge.svg?branch=master)](https://coveralls.io/github/danilobuerger/autocert-s3-cache?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/danilobuerger/autocert-s3-cache)](https://goreportcard.com/report/github.com/danilobuerger/autocert-s3-cache)
+[![GoDoc](https://godoc.org/github.com/danilobuerger/autocert-s3-cache?status.svg)](https://godoc.org/github.com/danilobuerger/autocert-s3-cache) [![Build Status](https://travis-ci.org/danilobuerger/autocert-s3-cache.svg?branch=master)](https://travis-ci.org/danilobuerger/autocert-s3-cache) [![Coverage Status](https://coveralls.io/repos/github/danilobuerger/autocert-s3-cache/badge.svg?branch=master)](https://coveralls.io/github/danilobuerger/autocert-s3-cache?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/danilobuerger/autocert-s3-cache)](https://goreportcard.com/report/github.com/danilobuerger/autocert-s3-cache)
 
 # autocert-s3-cache
 

--- a/s3cache.go
+++ b/s3cache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -16,34 +17,78 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-// Logger logs.
+// Logger for outputing logs
 type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
+// Making sure that we're adhering to the autocert.Cache interface
 var _ autocert.Cache = (*Cache)(nil)
 
-// Cache provides an autocert s3 cache.
+// Cache provides a s3 backend to the autocert cache.
 type Cache struct {
 	bucket string
+	prefix string
 	s3     s3iface.S3API
 
 	Logger Logger
 }
 
-// New creates a autocert s3 cache.
-func New(region, bucket string) (*Cache, error) {
-	sess, err := session.NewSession(&aws.Config{
-		CredentialsChainVerboseErrors: aws.Bool(true),
-		Region: aws.String(region),
-	})
-	if err != nil {
-		return nil, err
+// OptFunc is for options passed in to New
+type OptFunc func(*options)
+
+// options holds options that can be used while making a new Cache object
+type options struct {
+	prefix  string
+	session s3iface.S3API
+}
+
+// returns an options object with defaults
+func newOptions() *options {
+	o := new(options)
+
+	// defaults
+	o.prefix = "/"
+	return o
+}
+
+// KeyPrefix adds an S3 key prefix to the certs stored
+func KeyPrefix(prefix string) OptFunc {
+	return func(o *options) {
+		o.prefix = strings.TrimRight(prefix, "/") + "/"
+	}
+}
+
+// s3session is for overwriting the s3 interface during testing
+func s3session(session s3iface.S3API) OptFunc {
+	return func(o *options) {
+		o.session = session
+	}
+}
+
+// New creates an s3 interface to the autocert cache.
+func New(region, bucket string, opts ...OptFunc) (*Cache, error) {
+
+	option := newOptions()
+	for _, opt := range opts {
+		opt(option)
+	}
+
+	if option.session == nil {
+		sess, err := session.NewSession(&aws.Config{
+			CredentialsChainVerboseErrors: aws.Bool(true),
+			Region: aws.String(region),
+		})
+		if err != nil {
+			return nil, err
+		}
+		option.session = s3.New(sess)
 	}
 
 	return &Cache{
 		bucket: bucket,
-		s3:     s3.New(sess),
+		prefix: option.prefix,
+		s3:     option.session,
 	}, nil
 }
 
@@ -51,7 +96,7 @@ func (c *Cache) log(format string, v ...interface{}) {
 	if c.Logger == nil {
 		return
 	}
-	c.Logger.Printf(format, v)
+	c.Logger.Printf(format, v...)
 }
 
 func (c *Cache) get(key string) ([]byte, error) {
@@ -69,7 +114,8 @@ func (c *Cache) get(key string) ([]byte, error) {
 
 // Get returns a certificate data for the specified key.
 func (c *Cache) Get(ctx context.Context, key string) ([]byte, error) {
-	c.log("Cache Get %s", key)
+	key = c.prefix + key
+	c.log("S3 Cache Get %s", key)
 
 	var (
 		data []byte
@@ -109,7 +155,8 @@ func (c *Cache) put(key string, data []byte) error {
 
 // Put stores the data in the cache under the specified key.
 func (c *Cache) Put(ctx context.Context, key string, data []byte) error {
-	c.log("Cache Put %s", key)
+	key = c.prefix + key
+	c.log("S3 Cache Put %s", key)
 
 	var (
 		err  error
@@ -140,6 +187,7 @@ func (c *Cache) delete(key string) error {
 
 // Delete removes a certificate data from the cache under the specified key.
 func (c *Cache) Delete(ctx context.Context, key string) error {
+	key = c.prefix + key
 	c.log("Cache Delete %s", key)
 
 	var (

--- a/s3cache.go
+++ b/s3cache.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2016 Danilo Bürger <info@danilobuerger.de>
 
+// package s3cache implements a https://godoc.org/golang.org/x/crypto/acme/autocert Cache to store keys within in a S3 bucket. If the key does not exist, it will be created automatically.
 package s3cache
 
 import (

--- a/s3cache_test.go
+++ b/s3cache_test.go
@@ -16,6 +16,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// s3session is for overwriting the s3 interface during testing
+func s3session(session s3iface.S3API) OptFunc {
+	return func(o *options) {
+		o.session = session
+	}
+}
+
 type testLogger struct {
 	called bool
 }
@@ -135,4 +142,97 @@ func TestCacheWithPrefix(t *testing.T) {
 
 	_, err = cache.Get(ctx, "dummy")
 	assert.Equal(t, autocert.ErrCacheMiss, err)
+}
+
+func TestCacheWithDSN(t *testing.T) {
+	testCache := &testS3{cache: map[string][]byte{}}
+	cache, err := NewDSN("s3://my-bucket/path/to/certs/here", s3session(testCache))
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	assert.Equal(t, cache.bucket, "my-bucket")
+
+	_, err = cache.Get(ctx, "nonexistent")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+
+	b1 := []byte{1}
+	assert.NoError(t, cache.Put(ctx, "dummy", b1))
+
+	assert.Contains(t, testCache.cache, "/path/to/certs/here/dummy")
+
+	b2, err := cache.Get(ctx, "dummy")
+	assert.NoError(t, err)
+	assert.Equal(t, b1, b2)
+
+	assert.NoError(t, cache.Delete(ctx, "dummy"))
+
+	_, err = cache.Get(ctx, "dummy")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+}
+
+func TestParseS3DSN(t *testing.T) {
+	type rtn struct{ region, bucket, prefix string }
+	var tests = []struct {
+		name  string
+		dsn   string
+		want  rtn
+		wante error
+	}{
+		{
+			name: "bucket in path, no host",
+			dsn:  "s3://example/dev/test/path",
+			want: rtn{region: "us-east-1", bucket: "example", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in path (looks like a domain), no host",
+			dsn:  "s3://example.com/dev/test/path",
+			want: rtn{region: "us-east-1", bucket: "example.com", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in domain, no region",
+			dsn:  "s3://example.com.s3.amazonaws.com/dev/test/path",
+			want: rtn{region: "us-east-1", bucket: "example.com", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in path, no region",
+			dsn:  "s3://s3.amazonaws.com/example.com/dev/test/path",
+			want: rtn{region: "us-east-1", bucket: "example.com", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in path, with region",
+			dsn:  "s3://s3-us-west-1.amazonaws.com/example.com/dev/test/path",
+			want: rtn{region: "us-west-1", bucket: "example.com", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in domain, with region",
+			dsn:  "s3://example.com.s3-us-west-1.amazonaws.com/dev/test/path",
+			want: rtn{region: "us-west-1", bucket: "example.com", prefix: "/dev/test/path"},
+		},
+		{
+			name: "bucket in domain, with no region, no path",
+			dsn:  "s3://example.com.s3.amazonaws.com/",
+			want: rtn{region: "us-east-1", bucket: "example.com", prefix: "/"},
+		},
+	}
+
+	for _, test := range tests {
+		have, havee := parseS3DSN(test.dsn)
+		if test.wante == nil && have.bucket != test.want.bucket {
+			t.Errorf("%s:\nhave: %q want: %q", test.name, have.bucket, test.want.bucket)
+		}
+
+		if test.wante == nil && have.prefix != test.want.prefix {
+			t.Errorf("%s:\nhave: %q want: %q", test.name, have.prefix, test.want.prefix)
+		}
+
+		if test.wante == nil && have.region != test.want.region {
+			t.Errorf("%s:\nhave: %q want: %q", test.name, have.region, test.want.region)
+		}
+
+		if test.wante != nil {
+			if havee != test.wante {
+				t.Errorf(`%s:\nhave: "%v" want: "%v"`, test.name, havee, test.wante)
+			}
+		}
+	}
 }

--- a/s3cache_test.go
+++ b/s3cache_test.go
@@ -87,3 +87,52 @@ func TestCache(t *testing.T) {
 	_, err = cache.Get(ctx, "dummy")
 	assert.Equal(t, autocert.ErrCacheMiss, err)
 }
+
+func TestCacheWithOption(t *testing.T) {
+	cache, err := New("", "my-bucket", s3session(&testS3{cache: map[string][]byte{}}))
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	assert.Equal(t, cache.bucket, "my-bucket")
+
+	_, err = cache.Get(ctx, "nonexistent")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+
+	b1 := []byte{1}
+	assert.NoError(t, cache.Put(ctx, "dummy", b1))
+
+	b2, err := cache.Get(ctx, "dummy")
+	assert.NoError(t, err)
+	assert.Equal(t, b1, b2)
+
+	assert.NoError(t, cache.Delete(ctx, "dummy"))
+
+	_, err = cache.Get(ctx, "dummy")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+}
+
+func TestCacheWithPrefix(t *testing.T) {
+	testCache := &testS3{cache: map[string][]byte{}}
+	cache, err := New("", "my-bucket", s3session(testCache), KeyPrefix("/path/to/certs/here"))
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	assert.Equal(t, cache.bucket, "my-bucket")
+
+	_, err = cache.Get(ctx, "nonexistent")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+
+	b1 := []byte{1}
+	assert.NoError(t, cache.Put(ctx, "dummy", b1))
+
+	assert.Contains(t, testCache.cache, "/path/to/certs/here/dummy")
+
+	b2, err := cache.Get(ctx, "dummy")
+	assert.NoError(t, err)
+	assert.Equal(t, b1, b2)
+
+	assert.NoError(t, cache.Delete(ctx, "dummy"))
+
+	_, err = cache.Get(ctx, "dummy")
+	assert.Equal(t, autocert.ErrCacheMiss, err)
+}


### PR DESCRIPTION
Adds a `NewS3DSN` function to so that a cache can be created from a S3 DSN. With tests. 